### PR TITLE
Fluka.Cern integration

### DIFF
--- a/ATLHECTB.cc
+++ b/ATLHECTB.cc
@@ -10,6 +10,11 @@
 //
 #include "ATLHECTBActionInitialization.hh"
 #include "ATLHECTBDetectorConstruction.hh"
+#ifdef G4_USE_FLUKA
+// include the FTFP_BERT PL custmized with fluka
+// hadron inelastic process
+#include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+#endif
 
 // Includers from Geant4
 //
@@ -36,7 +41,6 @@
 // Includers from FLUKAIntegration
 //
 #ifdef G4_USE_FLUKA
-#include "G4_HP_CernFLUKAHadronInelastic_PhysicsList.hh"
 #include "FLUKAParticleTable.hh"
 #endif
 
@@ -165,6 +169,7 @@ int main(int argc, char** argv)
     PrintPLFactoryUsageError::PLFactoryUsageError();
     return 1;
   }
+
 #ifndef G4_USE_FLUKA
   auto physList = physListFactory->GetReferencePhysList(custom_pl);
   physList->RegisterPhysics(new G4StepLimiterPhysics());
@@ -173,7 +178,7 @@ int main(int argc, char** argv)
   // physList->RegisterPhysics(nCut);
   runManager->SetUserInitialization(physList);
 #else
-  auto physList = new G4_HP_CernFLUKAHadronInelastic_PhysicsList();
+  auto physList = new G4_CernFLUKAHadronInelastic_FTFP_BERT;
   runManager->SetUserInitialization(physList);
    // Initialize FLUKA <-> G4 particles conversions tables.
    fluka_particle_table::initialize();

--- a/ATLHECTB.cc
+++ b/ATLHECTB.cc
@@ -13,7 +13,7 @@
 #ifdef G4_USE_FLUKA
 // include the FTFP_BERT PL custmized with fluka
 // hadron inelastic process
-#include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+#  include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
 #endif
 
 // Includers from Geant4
@@ -41,7 +41,7 @@
 // Includers from FLUKAIntegration
 //
 #ifdef G4_USE_FLUKA
-#include "FLUKAParticleTable.hh"
+#  include "FLUKAParticleTable.hh"
 #endif
 
 // Includers from C++ STL
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
   }  // end of converting arguments
 
 #ifndef G4_USE_FLUKA
-#if G4VERSION_NUMBER >= 1110  // >= Geant4-11.1.0
+#  if G4VERSION_NUMBER >= 1110  // >= Geant4-11.1.0
   G4bool UseFTFTune = false;
   G4int FTFTuneIndex = 99;
   if (custom_pl.find("tune") != std::string::npos) {
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
     G4cout << "----------> Using FTF alternative tune index: " << FTFTuneIndex
            << " and PL: " << custom_pl << " <----------" << G4endl;
   }
-#endif
+#  endif
 #endif
 
   // Activate interaction mode if no macro card is provided and define UI session
@@ -184,15 +184,15 @@ int main(int argc, char** argv)
 #else
   auto physList = new G4_CernFLUKAHadronInelastic_FTFP_BERT;
   runManager->SetUserInitialization(physList);
-   // Initialize FLUKA <-> G4 particles conversions tables.
-   fluka_particle_table::initialize();
-#endif //#ifndef G4_USE_FLUKA
+  // Initialize FLUKA <-> G4 particles conversions tables.
+  fluka_particle_table::initialize();
+#endif  // #ifndef G4_USE_FLUKA
 
 // Set FTF tunings (only => Geant4-11.1.0)
 // prevent FTF tunings usage when FLUKA is used
 //
 #ifndef G4_USE_FLUKA
-#if G4VERSION_NUMBER >= 1110  // => Geant4-11.1.0
+#  if G4VERSION_NUMBER >= 1110  // => Geant4-11.1.0
   if (UseFTFTune) {
     auto FTFTunings = G4FTFTunings::Instance();
     if (FTFTuneIndex == 0)
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
       return 1;
     }
   }
-#endif
+#  endif
 #endif
 
   // ActionInitialization part

--- a/ATLHECTB.cc
+++ b/ATLHECTB.cc
@@ -120,6 +120,7 @@ int main(int argc, char** argv)
     }
   }  // end of converting arguments
 
+#ifndef G4_USE_FLUKA
 #if G4VERSION_NUMBER >= 1110  // >= Geant4-11.1.0
   G4bool UseFTFTune = false;
   G4int FTFTuneIndex = 99;
@@ -132,6 +133,7 @@ int main(int argc, char** argv)
     G4cout << "----------> Using FTF alternative tune index: " << FTFTuneIndex
            << " and PL: " << custom_pl << " <----------" << G4endl;
   }
+#endif
 #endif
 
   // Activate interaction mode if no macro card is provided and define UI session
@@ -164,11 +166,13 @@ int main(int argc, char** argv)
   auto DetConstruction = new ATLHECTBDetectorConstruction();
   runManager->SetUserInitialization(DetConstruction);
 
+#ifndef G4_USE_FLUKA
   auto physListFactory = new G4PhysListFactory;
   if (!physListFactory->IsReferencePhysList(custom_pl)) {  // if custom_pl is not a PLname exit
     PrintPLFactoryUsageError::PLFactoryUsageError();
     return 1;
   }
+#endif
 
 #ifndef G4_USE_FLUKA
   auto physList = physListFactory->GetReferencePhysList(custom_pl);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,38 @@ else()
     find_package(Geant4 REQUIRED)
 endif()
 
-#Setup Geant4 include directories and project include directories
+#Setup Geant4 include directories and compile definitions
 #
 include(${Geant4_USE_FILE})
-include_directories(${PROJECT_SOURCE_DIR}/include)
+
+#Find FLUKAInterface, this part is taken from /examples/extenedd/hadronic/FLUKACern/FlukaInterface/README.md
+#as in geant4-11.1.ref05 (May 2023)
+# FindFLUKAInterface.cmake is located at your_path_to_geant4/cmake/Modules/FindFLUKAInterface.cmake
+# Check that FindFLUKAInterface.cmake can be found from $CMAKE_MODULE_PATH
+message(STATUS "CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
+# Otherwise, you can always prepend it to the cmake module search path with:
+# set(CMAKE_MODULE_PATH my_path_to_find_fluka ${CMAKE_MODULE_PATH})
+
+# Check whether FLUKA should be used or not
+set(G4_USE_FLUKA OFF CACHE BOOL "Using FLUKA")
+if(G4_USE_FLUKA)
+  message(STATUS "G4_USE_FLUKA=ON : Using FLUKA interface for building ${PROJECT_SOURCE_DIR}")
+  add_definitions(-DG4_USE_FLUKA)
+  find_package(FLUKAInterface REQUIRED)
+  if(FLUKAInterface_FOUND)
+    message(STATUS "FLUKA cmake module was found : ${CMAKE_MODULE_PATH}")
+  else()
+    message(FATAL_ERROR "FLUKA cmake module was NOT found! Please add one.")
+  endif()
+else()
+  message(STATUS "G4_USE_FLUKA=OFF : NOT using FLUKA interface for building ${PROJECT_SOURCE_DIR}. \n \
+  If ever you want to use the FLUKA interface, please repeat cmake command with -DG4_USE_FLUKA=1")
+endif()
+#End of find FLUKAInterface
+
+#Setup project include directories
+#
+include_directories(${PROJECT_SOURCE_DIR}/include ${FLUKAInterface_INCLUDE_DIR})
 
 #Locate project source and headers
 #
@@ -35,7 +63,7 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 #Add executable and link it to Geant4 libraries
 #
 add_executable(ATLHECTB ATLHECTB.cc ${sources} ${headers})
-target_link_libraries(ATLHECTB ${Geant4_LIBRARIES})
+target_link_libraries(ATLHECTB ${Geant4_LIBRARIES} ${FLUKAInterface_LIBRARIES})
 
 #Copy all scripts to the build directory
 #

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ At the first execution, it will create the ATLHECTBgeo.gdml file with the up to 
    /cvmfs/sft.cern.ch/lcg/contrib/CMake/3.23.2/Linux-x86_64/bin/cmake -DG4_USE_FLUKA=1 ../ATLHECTB/
    make
    ```
+   NOTE: the Fluka.Cern interface can only be used in single-threaded mode.
 
 **[⬆ back to top](#atlhectb)**
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
         <li><a href="#submit-a-job-with-htcondor-on-lxplus">Submit a job with HTCondor on lxplus</a></li>
         <li><a href="#get-atlas-hec-geo-parameters-from-mysql-database">Get ATLAS HEC geo parameters from mysql database</a></li>
         <li><a href="#dump-atlhectb-gdml-geometry-description-file">Dump ATLHECTB GDML geometry description file</a></li>
+        <li><a href="#use-flukacern-hadron-inelastic-process">Use Fluka.Cern hadron inelastic process</a></li>
       </ul>
     </li>
     </li><li><a href="#geant4-and-github-actions">Geant4 and Github Actions</a></li>  
@@ -370,6 +371,33 @@ We support GDML geometry description. By default it is not active, to activate i
       fDumpGDMLgeo(true){}
    ```
 At the first execution, it will create the ATLHECTBgeo.gdml file with the up to date GDML geometry description.
+
+### Use Fluka.Cern hadron inelastic process
+`Geant4-11.1-ref05` introduces a Fluka.Cern interface to use the Fluka.Cern hadron inelastic process in any geant4 application as explained in `examples/extended/hadronic/FlukaCern`. The following are my instructions to use this repo with a customized FTFP_BERT physics list using it. It assumes that cvmfs is mounted.
+1. Install fluka4-3.3
+   ```sh
+   source /cvmfs/sft.cern.ch/lcg/contrib/gcc/10.1.0/x86_64-centos7/setup.sh
+   cd fluka4-3.3 && make -j 4
+   cd src/ && make cpp_headers
+   mkdir /path-to/fluka4-3.3-install && make install DESTDIR=/path-to/fluka4-3.3-install/
+   PATH="/users/lopezzot/fluka4-3.3-install/bin/":$PATH
+   ```
+2. Setup `geant4-11.1.ref05` and compile the fluka interface as in the example
+   ```sh
+   source /cvmfs/geant4.cern.ch/geant4/11.1.ref05/x86_64-centos7-gcc10-optdeb-MT/CMake-setup.sh 
+   source /cvmfs/geant4.cern.ch/geant4/11.1.ref05/x86_64-centos7-gcc10-optdeb-MT/bin/geant4.sh 
+   cd FlukaCern/FlukaInterface/
+   make interface
+   make env
+   source env_FLUKA_G4_interface.sh 
+   ```
+3. Build and execute ATLHECTB
+   ```sh
+   git clone https://github.com/lopezzot/ATLHECTB.git
+   mkdir ATLHECTB-build && cd ATLHECTB-build
+   /cvmfs/sft.cern.ch/lcg/contrib/CMake/3.23.2/Linux-x86_64/bin/cmake -DG4_USE_FLUKA=1 ../ATLHECTB/
+   make
+   ```
 
 **[⬆ back to top](#atlhectb)**
 

--- a/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
+++ b/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
@@ -14,26 +14,26 @@ FLUKA interface included in geant4-11.1.ref05.
 */
 
 #ifdef G4_USE_FLUKA
-#ifndef G4_CernFLUKAHadronInelastic_FTFP_BERT_h
-#define G4_CernFLUKAHadronInelastic_FTFP_BERT_h 1
+#  ifndef G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#    define G4_CernFLUKAHadronInelastic_FTFP_BERT_h 1
 
-#include <CLHEP/Units/SystemOfUnits.h>
+#    include "G4VModularPhysicsList.hh"
+#    include "globals.hh"
 
-#include "globals.hh"
-#include "G4VModularPhysicsList.hh"
+#    include <CLHEP/Units/SystemOfUnits.h>
 
-class G4_CernFLUKAHadronInelastic_FTFP_BERT final : public G4VModularPhysicsList 
+class G4_CernFLUKAHadronInelastic_FTFP_BERT final : public G4VModularPhysicsList
 {
   public:
     G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver = 1);
-    virtual ~G4_CernFLUKAHadronInelastic_FTFP_BERT()=default;
+    virtual ~G4_CernFLUKAHadronInelastic_FTFP_BERT() = default;
 
-    G4_CernFLUKAHadronInelastic_FTFP_BERT(const G4_CernFLUKAHadronInelastic_FTFP_BERT &) = delete;
-    G4_CernFLUKAHadronInelastic_FTFP_BERT & operator=(const G4_CernFLUKAHadronInelastic_FTFP_BERT &)=delete;
-		  
+    G4_CernFLUKAHadronInelastic_FTFP_BERT(const G4_CernFLUKAHadronInelastic_FTFP_BERT&) = delete;
+    G4_CernFLUKAHadronInelastic_FTFP_BERT&
+    operator=(const G4_CernFLUKAHadronInelastic_FTFP_BERT&) = delete;
 };
 
-#endif //G4_CernFLUKAHadronInelastic_FTFP_BERT_h
-#endif //G4_USE_FLUKA
+#  endif  // G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#endif  // G4_USE_FLUKA
 
 //**************************************************

--- a/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
+++ b/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
@@ -1,0 +1,39 @@
+//**************************************************
+// \file G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
+// \brief: Definition
+// G4_CernFLUKAHadronInelastic_FTFP_BERT.hh class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 2 June 2023
+//**************************************************
+
+/*Note:
+This class is a customization of the FTFP_BERT physics list
+to use the HadronInelastic process of FLUKA via the
+FLUKA interface included in geant4-11.1.ref05.
+*/
+
+#ifdef G4_USE_FLUKA
+#ifndef G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#define G4_CernFLUKAHadronInelastic_FTFP_BERT_h 1
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include "globals.hh"
+#include "G4VModularPhysicsList.hh"
+
+class G4_CernFLUKAHadronInelastic_FTFP_BERT final : public G4VModularPhysicsList 
+{
+  public:
+    G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver = 1);
+    virtual ~G4_CernFLUKAHadronInelastic_FTFP_BERT()=default;
+
+    G4_CernFLUKAHadronInelastic_FTFP_BERT(const G4_CernFLUKAHadronInelastic_FTFP_BERT &) = delete;
+    G4_CernFLUKAHadronInelastic_FTFP_BERT & operator=(const G4_CernFLUKAHadronInelastic_FTFP_BERT &)=delete;
+		  
+};
+
+#endif //G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#endif //G4_USE_FLUKA
+
+//**************************************************

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -1,0 +1,90 @@
+//**************************************************
+// \file G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+// \brief: Implementation of
+// G4_CernFLUKAHadronInelastic_FTFP_BERT class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 2 June 2021
+//**************************************************
+
+/*Note:
+This class is a customization of the FTFP_BERT physics list
+to use the HadronInelastic process of FLUKA via the
+FLUKA interface included in geant4-11.1.ref05.
+*/
+
+#ifdef G4_USE_FLUKA
+
+//Includers from project files
+//
+#include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+
+//Includers from Geant4
+//
+#include <iomanip>   
+#include "globals.hh"
+#include "G4ios.hh"
+#include "G4DecayPhysics.hh"
+#include "G4EmStandardPhysics.hh"
+#include "G4EmExtraPhysics.hh"
+#include "G4IonPhysics.hh"
+#include "G4StoppingPhysics.hh"
+#include "G4HadronElasticPhysics.hh"
+#include "G4NeutronTrackingCut.hh"
+//#include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysicsConstructor.hh
+
+//Includers from FLUKA interface
+//
+#include "FLUKAHadronInelasticPhysicsConstructor.hh"
+#include "fluka_interface.hh"
+
+G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver)
+{
+  if(ver > 0) {
+    G4cout << "<<< Geant4 Physics List simulation engine: FTFP_BERT PL customized with FLUKAHadronInelasticPhysicsConstructor"<<G4endl;
+    G4cout <<G4endl;
+  }
+
+  defaultCutValue = 0.7*CLHEP::mm;  
+  SetVerboseLevel(ver);
+
+  // EM Physics
+  RegisterPhysics( new G4EmStandardPhysics(ver));
+
+  // Synchroton Radiation & GN Physics
+  RegisterPhysics( new G4EmExtraPhysics(ver) );
+
+  // Decays 
+  RegisterPhysics( new G4DecayPhysics(ver) );
+
+  // Hadron Elastic scattering
+  RegisterPhysics( new G4HadronElasticPhysics(ver) );
+
+  // Hadron Physics
+  // RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+  RegisterPhysics( new FLUKAHadronInelasticPhysicsConstructor( ver ) );
+  
+  // Stopping Physics
+  RegisterPhysics( new G4StoppingPhysics(ver) );
+
+  // Ion Physics
+  RegisterPhysics( new G4IonPhysics(ver));
+
+  // Neutron tracking cut
+  RegisterPhysics( new G4NeutronTrackingCut(ver));
+
+  // IMPORTANT: Initialize the FLUKA interface here.
+  // Both activation switches should be set to TRUE to provide the most comprehensive results.
+  // NB: COMPARISON WITH G4 DOES NOT SEEM MEANINGFUL 
+  // WHEN COALESCENCE IS ACTIVATED IN BOTH FLUKA AND G4.
+  // Freedom to choose & see the effect of these switches is hence provided here.
+  const G4bool activateCoalescence = true;
+  const G4bool activateHeavyFragmentsEvaporation = true;
+  fluka_interface::initialize(activateCoalescence, 
+                              activateHeavyFragmentsEvaporation);
+                 
+}
+
+#endif //G4_USE_FLUKA
+
+//**************************************************

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -15,76 +15,77 @@ FLUKA interface included in geant4-11.1.ref05.
 
 #ifdef G4_USE_FLUKA
 
-//Includers from project files
+// Includers from project files
 //
-#include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+#  include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
 
-//Includers from Geant4
+// Includers from Geant4
 //
-#include <iomanip>   
-#include "globals.hh"
-#include "G4ios.hh"
-#include "G4DecayPhysics.hh"
-#include "G4EmStandardPhysics.hh"
-#include "G4EmExtraPhysics.hh"
-#include "G4IonPhysics.hh"
-#include "G4StoppingPhysics.hh"
-#include "G4HadronElasticPhysics.hh"
-#include "G4NeutronTrackingCut.hh"
-//#include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysicsConstructor.hh
+#  include "G4DecayPhysics.hh"
+#  include "G4EmExtraPhysics.hh"
+#  include "G4EmStandardPhysics.hh"
+#  include "G4HadronElasticPhysics.hh"
+#  include "G4IonPhysics.hh"
+#  include "G4NeutronTrackingCut.hh"
+#  include "G4StoppingPhysics.hh"
+#  include "G4ios.hh"
+#  include "globals.hh"
 
-//Includers from FLUKA interface
+#  include <iomanip>
+// #include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysicsConstructor.hh
+
+// Includers from FLUKA interface
 //
-#include "FLUKAHadronInelasticPhysicsConstructor.hh"
-#include "fluka_interface.hh"
+#  include "FLUKAHadronInelasticPhysicsConstructor.hh"
+#  include "fluka_interface.hh"
 
 G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver)
 {
-  if(ver > 0) {
-    G4cout << "<<< Geant4 Physics List simulation engine: FTFP_BERT PL customized with FLUKAHadronInelasticPhysicsConstructor"<<G4endl;
-    G4cout <<G4endl;
+  if (ver > 0) {
+    G4cout << "<<< Geant4 Physics List simulation engine: FTFP_BERT PL customized with "
+              "FLUKAHadronInelasticPhysicsConstructor"
+           << G4endl;
+    G4cout << G4endl;
   }
 
-  defaultCutValue = 0.7*CLHEP::mm;  
+  defaultCutValue = 0.7 * CLHEP::mm;
   SetVerboseLevel(ver);
 
   // EM Physics
-  RegisterPhysics( new G4EmStandardPhysics(ver));
+  RegisterPhysics(new G4EmStandardPhysics(ver));
 
   // Synchroton Radiation & GN Physics
-  RegisterPhysics( new G4EmExtraPhysics(ver) );
+  RegisterPhysics(new G4EmExtraPhysics(ver));
 
-  // Decays 
-  RegisterPhysics( new G4DecayPhysics(ver) );
+  // Decays
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   // Hadron Elastic scattering
-  RegisterPhysics( new G4HadronElasticPhysics(ver) );
+  RegisterPhysics(new G4HadronElasticPhysics(ver));
 
   // Hadron Physics
   // RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
-  RegisterPhysics( new FLUKAHadronInelasticPhysicsConstructor( ver ) );
-  
+  RegisterPhysics(new FLUKAHadronInelasticPhysicsConstructor(ver));
+
   // Stopping Physics
-  RegisterPhysics( new G4StoppingPhysics(ver) );
+  RegisterPhysics(new G4StoppingPhysics(ver));
 
   // Ion Physics
-  RegisterPhysics( new G4IonPhysics(ver));
+  RegisterPhysics(new G4IonPhysics(ver));
 
   // Neutron tracking cut
-  RegisterPhysics( new G4NeutronTrackingCut(ver));
+  RegisterPhysics(new G4NeutronTrackingCut(ver));
 
   // IMPORTANT: Initialize the FLUKA interface here.
   // Both activation switches should be set to TRUE to provide the most comprehensive results.
-  // NB: COMPARISON WITH G4 DOES NOT SEEM MEANINGFUL 
+  // NB: COMPARISON WITH G4 DOES NOT SEEM MEANINGFUL
   // WHEN COALESCENCE IS ACTIVATED IN BOTH FLUKA AND G4.
   // Freedom to choose & see the effect of these switches is hence provided here.
   const G4bool activateCoalescence = true;
   const G4bool activateHeavyFragmentsEvaporation = true;
-  fluka_interface::initialize(activateCoalescence, 
-                              activateHeavyFragmentsEvaporation);
-                 
+  fluka_interface::initialize(activateCoalescence, activateHeavyFragmentsEvaporation);
 }
 
-#endif //G4_USE_FLUKA
+#endif  // G4_USE_FLUKA
 
 //**************************************************

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -4,7 +4,7 @@
 // G4_CernFLUKAHadronInelastic_FTFP_BERT class
 // \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
 //          @lopezzot
-// \start date: 2 June 2021
+// \start date: 2 June 2023
 //**************************************************
 
 /*Note:
@@ -42,7 +42,7 @@ FLUKA interface included in geant4-11.1.ref05.
 G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver)
 {
   if (ver > 0) {
-    G4cout << "<<< Geant4 Physics List simulation engine: FTFP_BERT PL customized with "
+    G4cout << "Geant4 Physics List simulation engine: FTFP_BERT PL customized with "
               "FLUKAHadronInelasticPhysicsConstructor"
            << G4endl;
     G4cout << G4endl;


### PR DESCRIPTION
This PR includes the changes needed to use the Fluka.Cern interface to the hadron inelastic scattering process as in `geant4-11.1.ref05`:
- changes in CMakeLists.txt (1d45ed6de2a11425ee21f7ba0180bf7e353f9760)
- introduce the FTFP_BERT PL with Fluka process (0df32b91ca4c80e8f0198f569f1256d4d7c45c61 18786135882a7462aa1c04f4bd9baac2b872913b 49b800fa001d7bbd8873fab11e174dd58b642c83)
- Format and small changes (3dcc24b3d07560abcb2c56501261a3c1d1562048 2414eeefa21308aa54aeb45680218df0c6f4c523)
- Add documentation (5cef16fc1fc6b2ce7054495d4082cac4bd3e0367 e2f20e6289b92a060672d3ba27a70b2def9836ec)