### PR TITLE
FLUKA.CERN inelastic constructor

### DIFF
--- a/include/FLUKAHadronInelasticPhysics.hh
+++ b/include/FLUKAHadronInelasticPhysics.hh
@@ -1,0 +1,52 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
+//
+// Author: G.Hugo, 01 August 2022
+//
+// History: L. Pezzotti adaption of the FLUKAHadronInelasticPhysicsConstructor
+// by G. Hugo to not include the HP treatment for neutrons. (June 6, 2023)
+// ***************************************************************************
+#ifdef G4_USE_FLUKA
+#ifndef FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#define FLUKA_HADRON_INELASTIC_PHYSICS_HH 1
+
+// G4
+#include "G4VPhysicsConstructor.hh"
+
+class FLUKAHadronInelasticPhysics final : public G4VPhysicsConstructor {
+
+public:
+  FLUKAHadronInelasticPhysics(G4int verbose = 1);
+
+  virtual void ConstructParticle() override;
+  virtual void ConstructProcess() override;
+
+};
+
+
+#endif // FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#endif // G4_USE_FLUKA

--- a/include/FLUKAHadronInelasticPhysics.hh
+++ b/include/FLUKAHadronInelasticPhysics.hh
@@ -1,52 +1,31 @@
-//
-// ********************************************************************
-// * License and Disclaimer                                           *
-// *                                                                  *
-// * The  Geant4 software  is  copyright of the Copyright Holders  of *
-// * the Geant4 Collaboration.  It is provided  under  the terms  and *
-// * conditions of the Geant4 Software License,  included in the file *
-// * LICENSE and available at  http://cern.ch/geant4/license .  These *
-// * include a list of copyright holders.                             *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.  Please see the license in the file  LICENSE  and URL above *
-// * for the full disclaimer and the limitation of liability.         *
-// *                                                                  *
-// * This  code  implementation is the result of  the  scientific and *
-// * technical work of the GEANT4 collaboration.                      *
-// * By using,  copying,  modifying or  distributing the software (or *
-// * any work based  on the software)  you  agree  to acknowledge its *
-// * use  in  resulting  scientific  publications,  and indicate your *
-// * acceptance of all terms of the Geant4 Software license.          *
-// ********************************************************************
+// ***************************************************************************
 //
 // Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
 //
 // Author: G.Hugo, 01 August 2022
 //
-// History: L. Pezzotti adaption of the FLUKAHadronInelasticPhysicsConstructor
-// by G. Hugo to not include the HP treatment for neutrons. (June 6, 2023)
+// History: L. Pezzotti adaptation of the
+//          FLUKAHadronInelasticPhysicsConstructor by G. Hugo
+//          to not include the HP treatment for neutrons. (June 6, 2023)
 // ***************************************************************************
+
 #ifdef G4_USE_FLUKA
-#ifndef FLUKA_HADRON_INELASTIC_PHYSICS_HH
-#define FLUKA_HADRON_INELASTIC_PHYSICS_HH 1
+#  ifndef FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#    define FLUKA_HADRON_INELASTIC_PHYSICS_HH 1
 
 // G4
-#include "G4VPhysicsConstructor.hh"
+#    include "G4VPhysicsConstructor.hh"
 
-class FLUKAHadronInelasticPhysics final : public G4VPhysicsConstructor {
+class FLUKAHadronInelasticPhysics final : public G4VPhysicsConstructor
+{
+  public:
+    FLUKAHadronInelasticPhysics(G4int verbose = 1);
 
-public:
-  FLUKAHadronInelasticPhysics(G4int verbose = 1);
-
-  virtual void ConstructParticle() override;
-  virtual void ConstructProcess() override;
-
+    virtual void ConstructParticle() override;
+    virtual void ConstructProcess() override;
 };
 
+#  endif  // FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#endif  // G4_USE_FLUKA
 
-#endif // FLUKA_HADRON_INELASTIC_PHYSICS_HH
-#endif // G4_USE_FLUKA
+// ***************************************************************************

--- a/src/FLUKAHadronInelasticPhysics.cc
+++ b/src/FLUKAHadronInelasticPhysics.cc
@@ -1,0 +1,219 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+#ifdef G4_USE_FLUKA
+
+
+#include "FLUKAHadronInelasticPhysics.hh"
+
+// G4
+#include "G4MesonConstructor.hh"
+#include "G4BaryonConstructor.hh"
+#include "G4ShortLivedConstructor.hh"
+// G4
+#include "G4ParticleDefinition.hh"
+#include "G4PhysicsListHelper.hh"
+// G4
+#include "G4HadParticles.hh"
+#include "G4HadronicParameters.hh"
+// G4
+#include "G4NeutronCaptureProcess.hh"
+#include "G4NeutronRadCapture.hh"
+// G4
+#include "G4HadronInelasticProcess.hh"
+
+#include "build_G4_process_helpers.hh"
+
+#include "FLUKAInelasticScatteringXS.hh"
+#include "FLUKANuclearInelasticModel.hh"
+
+
+// DEBUG: CHERRY PICK FTFP_BERT XS / MODELS INSTEAD
+//#include "G4BGGNucleonInelasticXS.hh"
+//#include "G4TheoFSGenerator.hh"
+//#include "G4GeneratorPrecompoundInterface.hh"
+//#include "G4FTFModel.hh"
+//#include "G4ExcitedStringDecay.hh"
+//#include "G4QuasiElasticChannel.hh"
+
+
+// ***************************************************************************
+// Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
+// ***************************************************************************
+FLUKAHadronInelasticPhysics::FLUKAHadronInelasticPhysics(G4int verbose)
+:  G4VPhysicsConstructor("hInelastic FLUKA")
+{
+  if (verbose > 1) { 
+    G4cout << "### FLUKA Hadron Inelastic Physics" << G4endl;
+  }
+
+  const auto param = G4HadronicParameters::Instance();
+  param->SetEnableBCParticles(true);
+}
+
+
+// ***************************************************************************
+// Construct particles. 
+// ***************************************************************************
+void FLUKAHadronInelasticPhysics::ConstructParticle() {
+  G4MesonConstructor pMesonConstructor;
+  pMesonConstructor.ConstructParticle();
+
+  G4BaryonConstructor pBaryonConstructor;
+  pBaryonConstructor.ConstructParticle();
+
+  G4ShortLivedConstructor pShortLivedConstructor;
+  pShortLivedConstructor.ConstructParticle();  
+}
+
+
+// ***************************************************************************
+// For each particle of interest, 
+// processes are created, assigned XS and models, and registered to the process manager.
+//
+// IMPORTANT NB: The XS (G4VCrossSectionDataSet), models (G4HadronicInteraction), 
+// and even processes (G4HadronInelasticProcess) 
+// are constructed in a similar way as for any other G4 physics list in G4 source code.
+// They do not seem to be OWNED by the G4CrossSectionDataStore, G4EnergyRangeManager 
+// and G4ProcessManager respectively, HENCE THEY ARE NEVER DELETED
+// (true for ANY physics list).
+// Should not matter too much though, because the destructions 
+// should have happened at the very end of the run anyway.
+// ***************************************************************************
+void FLUKAHadronInelasticPhysics::ConstructProcess() {
+
+  const auto helper = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // FLUKA hadron - nucleus inelastic XS
+  const auto flukaInelasticScatteringXS = new FLUKAInelasticScatteringXS();
+
+  // FLUKA hadron - nucleus model
+  const auto flukaModel = new FLUKANuclearInelasticModel();
+
+
+  // PROTON
+  build_G4_process_helpers::buildInelasticProcess(G4Proton::Proton(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+	
+  // DEBUG: CHERRY PICK G4 XS / MODELS INSTEAD
+  /*auto protonInelasticProcess = new G4HadronInelasticProcess("protonInelastic", G4Proton::Proton());
+    helper->RegisterProcess(protonInelasticProcess, G4Proton::Proton());	
+    protonInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
+    //auto BGG = new G4BGGNucleonInelasticXS(G4Proton::Proton());
+    //protonInelasticProcess->AddDataSet(BGG);
+
+    protonInelasticProcess->RegisterMe(flukaModel);
+    //auto theModel = new G4TheoFSGenerator("FTFP");
+    //auto theStringModel = new G4FTFModel();
+    //theStringModel->SetFragmentationModel(new G4ExcitedStringDecay());
+    //theModel->SetHighEnergyGenerator(theStringModel);
+    //theModel->SetQuasiElasticChannel(new G4QuasiElasticChannel());
+    //auto theCascade = new G4GeneratorPrecompoundInterface();
+    //theModel->SetTransport(theCascade);
+    //theModel->SetMinEnergy(G4HadronicParameters::Instance()->GetMinEnergyTransitionFTF_Cascade());
+    //theModel->SetMaxEnergy(G4HadronicParameters::Instance()->GetMaxEnergy());
+    //protonInelasticProcess->RegisterMe(theModel);
+    */
+
+  // NEUTRON
+  const auto neutron = G4Neutron::Neutron();
+
+  // NEUTRON INELASTIC
+  const auto neutronInelasticProcess = new G4HadronInelasticProcess("neutronInelastic", neutron);
+  // NB: No XS is set by default in the G4HadronInelasticProcess constructor.
+  helper->RegisterProcess(neutronInelasticProcess, neutron);
+
+  // Also non-HP: FLUKA neutron inelastic
+  // IMPORTANT NB: Since flukaInelasticScatteringXS is SetForAllAtomsAndEnergies,
+  // it needs to be set first (would erase any previously defined dataset, 
+  // see G4CrossSectionDataStore::AddDataSet).
+  neutronInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
+  const auto flukaNeutronModel = new FLUKANuclearInelasticModel();
+  neutronInelasticProcess->RegisterMe(flukaNeutronModel);
+
+  // TO DO: Not elegant to have G4 neutron capture and fission included in FLUKA inelastic. 
+  // Create a Physics constructor just for it? 
+  // (NB: CANNOT use the neutron builders, 
+  // because they would ALSO create a G4HadronInelasticProcess, while we use the FLUKA one).
+
+  // NEUTRON CAPTURE
+  const auto neutronCaptureProcess = new G4NeutronCaptureProcess();
+  // NB: XS (G4NeutronCaptureXS) is already added, in G4NeutronCaptureProcess constructor.
+  helper->RegisterProcess(neutronCaptureProcess, neutron);
+  const auto neutronRadCaptureModel = new G4NeutronRadCapture();
+  neutronCaptureProcess->RegisterMe(neutronRadCaptureModel);
+
+  // NO NEUTRON FISSION
+
+  // PI+, PI-
+  build_G4_process_helpers::buildInelasticProcess(G4PionPlus::PionPlus(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+  build_G4_process_helpers::buildInelasticProcess(G4PionMinus::PionMinus(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+
+
+  // KAONS
+  build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetKaons(), 
+                                                                 helper,
+                                                                 flukaInelasticScatteringXS,
+                                                                 flukaModel);
+
+
+  const auto param = G4HadronicParameters::Instance();
+  if (param->GetMaxEnergy() > param->EnergyThresholdForHeavyHadrons()) {
+
+    // HYPERONS, ANTI-HYPERONS
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetHyperons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetAntiHyperons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+
+    // LIGHT ANTI-IONS: PBAR, NBAR, ANTI LIGHT IONS
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetLightAntiIons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+
+    // B-, C- BARYONS AND MESONS
+    if (G4HadronicParameters::Instance()->EnableBCParticles() ) {
+      build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetBCHadrons(),
+                                                                     helper,
+                                                                     flukaInelasticScatteringXS,
+                                                                     flukaModel);
+    }
+  }
+}
+
+
+#endif // G4_USE_FLUKA

--- a/src/FLUKAHadronInelasticPhysics.cc
+++ b/src/FLUKAHadronInelasticPhysics.cc
@@ -1,70 +1,53 @@
+// ***************************************************************************
 //
-// ********************************************************************
-// * License and Disclaimer                                           *
-// *                                                                  *
-// * The  Geant4 software  is  copyright of the Copyright Holders  of *
-// * the Geant4 Collaboration.  It is provided  under  the terms  and *
-// * conditions of the Geant4 Software License,  included in the file *
-// * LICENSE and available at  http://cern.ch/geant4/license .  These *
-// * include a list of copyright holders.                             *
-// *                                                                  *
-// * Neither the authors of this software system, nor their employing *
-// * institutes,nor the agencies providing financial support for this *
-// * work  make  any representation or  warranty, express or implied, *
-// * regarding  this  software system or assume any liability for its *
-// * use.  Please see the license in the file  LICENSE  and URL above *
-// * for the full disclaimer and the limitation of liability.         *
-// *                                                                  *
-// * This  code  implementation is the result of  the  scientific and *
-// * technical work of the GEANT4 collaboration.                      *
-// * By using,  copying,  modifying or  distributing the software (or *
-// * any work based  on the software)  you  agree  to acknowledge its *
-// * use  in  resulting  scientific  publications,  and indicate your *
-// * acceptance of all terms of the Geant4 Software license.          *
-// ********************************************************************
+// Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
+//
+// Author: G.Hugo, 01 August 2022
+//
+// History: L. Pezzotti adaptation of the
+//          FLUKAHadronInelasticPhysicsConstructor by G. Hugo
+//          to not include the HP treatment for neutrons. (June 6, 2023)
+// ***************************************************************************
+
 #ifdef G4_USE_FLUKA
 
-
-#include "FLUKAHadronInelasticPhysics.hh"
+#  include "FLUKAHadronInelasticPhysics.hh"
 
 // G4
-#include "G4MesonConstructor.hh"
-#include "G4BaryonConstructor.hh"
-#include "G4ShortLivedConstructor.hh"
+#  include "G4BaryonConstructor.hh"
+#  include "G4MesonConstructor.hh"
+#  include "G4ShortLivedConstructor.hh"
 // G4
-#include "G4ParticleDefinition.hh"
-#include "G4PhysicsListHelper.hh"
+#  include "G4ParticleDefinition.hh"
+#  include "G4PhysicsListHelper.hh"
 // G4
-#include "G4HadParticles.hh"
-#include "G4HadronicParameters.hh"
+#  include "G4HadParticles.hh"
+#  include "G4HadronicParameters.hh"
 // G4
-#include "G4NeutronCaptureProcess.hh"
-#include "G4NeutronRadCapture.hh"
+#  include "G4NeutronCaptureProcess.hh"
+#  include "G4NeutronRadCapture.hh"
 // G4
-#include "G4HadronInelasticProcess.hh"
+#  include "G4HadronInelasticProcess.hh"
 
-#include "build_G4_process_helpers.hh"
-
-#include "FLUKAInelasticScatteringXS.hh"
-#include "FLUKANuclearInelasticModel.hh"
-
+#  include "FLUKAInelasticScatteringXS.hh"
+#  include "FLUKANuclearInelasticModel.hh"
+#  include "build_G4_process_helpers.hh"
 
 // DEBUG: CHERRY PICK FTFP_BERT XS / MODELS INSTEAD
-//#include "G4BGGNucleonInelasticXS.hh"
-//#include "G4TheoFSGenerator.hh"
-//#include "G4GeneratorPrecompoundInterface.hh"
-//#include "G4FTFModel.hh"
-//#include "G4ExcitedStringDecay.hh"
-//#include "G4QuasiElasticChannel.hh"
-
+// #include "G4BGGNucleonInelasticXS.hh"
+// #include "G4TheoFSGenerator.hh"
+// #include "G4GeneratorPrecompoundInterface.hh"
+// #include "G4FTFModel.hh"
+// #include "G4ExcitedStringDecay.hh"
+// #include "G4QuasiElasticChannel.hh"
 
 // ***************************************************************************
 // Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
 // ***************************************************************************
 FLUKAHadronInelasticPhysics::FLUKAHadronInelasticPhysics(G4int verbose)
-:  G4VPhysicsConstructor("hInelastic FLUKA")
+  : G4VPhysicsConstructor("hInelastic FLUKA")
 {
-  if (verbose > 1) { 
+  if (verbose > 1) {
     G4cout << "### FLUKA Hadron Inelastic Physics" << G4endl;
   }
 
@@ -72,11 +55,11 @@ FLUKAHadronInelasticPhysics::FLUKAHadronInelasticPhysics(G4int verbose)
   param->SetEnableBCParticles(true);
 }
 
-
 // ***************************************************************************
-// Construct particles. 
+// Construct particles.
 // ***************************************************************************
-void FLUKAHadronInelasticPhysics::ConstructParticle() {
+void FLUKAHadronInelasticPhysics::ConstructParticle()
+{
   G4MesonConstructor pMesonConstructor;
   pMesonConstructor.ConstructParticle();
 
@@ -84,25 +67,24 @@ void FLUKAHadronInelasticPhysics::ConstructParticle() {
   pBaryonConstructor.ConstructParticle();
 
   G4ShortLivedConstructor pShortLivedConstructor;
-  pShortLivedConstructor.ConstructParticle();  
+  pShortLivedConstructor.ConstructParticle();
 }
 
-
 // ***************************************************************************
-// For each particle of interest, 
+// For each particle of interest,
 // processes are created, assigned XS and models, and registered to the process manager.
 //
-// IMPORTANT NB: The XS (G4VCrossSectionDataSet), models (G4HadronicInteraction), 
-// and even processes (G4HadronInelasticProcess) 
+// IMPORTANT NB: The XS (G4VCrossSectionDataSet), models (G4HadronicInteraction),
+// and even processes (G4HadronInelasticProcess)
 // are constructed in a similar way as for any other G4 physics list in G4 source code.
-// They do not seem to be OWNED by the G4CrossSectionDataStore, G4EnergyRangeManager 
+// They do not seem to be OWNED by the G4CrossSectionDataStore, G4EnergyRangeManager
 // and G4ProcessManager respectively, HENCE THEY ARE NEVER DELETED
 // (true for ANY physics list).
-// Should not matter too much though, because the destructions 
+// Should not matter too much though, because the destructions
 // should have happened at the very end of the run anyway.
 // ***************************************************************************
-void FLUKAHadronInelasticPhysics::ConstructProcess() {
-
+void FLUKAHadronInelasticPhysics::ConstructProcess()
+{
   const auto helper = G4PhysicsListHelper::GetPhysicsListHelper();
 
   // FLUKA hadron - nucleus inelastic XS
@@ -111,16 +93,13 @@ void FLUKAHadronInelasticPhysics::ConstructProcess() {
   // FLUKA hadron - nucleus model
   const auto flukaModel = new FLUKANuclearInelasticModel();
 
-
   // PROTON
-  build_G4_process_helpers::buildInelasticProcess(G4Proton::Proton(),
-                                                  helper,
-                                                  flukaInelasticScatteringXS,
-                                                  flukaModel);
-	
+  build_G4_process_helpers::buildInelasticProcess(G4Proton::Proton(), helper,
+                                                  flukaInelasticScatteringXS, flukaModel);
+
   // DEBUG: CHERRY PICK G4 XS / MODELS INSTEAD
-  /*auto protonInelasticProcess = new G4HadronInelasticProcess("protonInelastic", G4Proton::Proton());
-    helper->RegisterProcess(protonInelasticProcess, G4Proton::Proton());	
+  /*auto protonInelasticProcess = new G4HadronInelasticProcess("protonInelastic",
+    G4Proton::Proton()); helper->RegisterProcess(protonInelasticProcess, G4Proton::Proton());
     protonInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
     //auto BGG = new G4BGGNucleonInelasticXS(G4Proton::Proton());
     //protonInelasticProcess->AddDataSet(BGG);
@@ -148,15 +127,15 @@ void FLUKAHadronInelasticPhysics::ConstructProcess() {
 
   // Also non-HP: FLUKA neutron inelastic
   // IMPORTANT NB: Since flukaInelasticScatteringXS is SetForAllAtomsAndEnergies,
-  // it needs to be set first (would erase any previously defined dataset, 
+  // it needs to be set first (would erase any previously defined dataset,
   // see G4CrossSectionDataStore::AddDataSet).
   neutronInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
   const auto flukaNeutronModel = new FLUKANuclearInelasticModel();
   neutronInelasticProcess->RegisterMe(flukaNeutronModel);
 
-  // TO DO: Not elegant to have G4 neutron capture and fission included in FLUKA inelastic. 
-  // Create a Physics constructor just for it? 
-  // (NB: CANNOT use the neutron builders, 
+  // TO DO: Not elegant to have G4 neutron capture and fission included in FLUKA inelastic.
+  // Create a Physics constructor just for it?
+  // (NB: CANNOT use the neutron builders,
   // because they would ALSO create a G4HadronInelasticProcess, while we use the FLUKA one).
 
   // NEUTRON CAPTURE
@@ -169,51 +148,35 @@ void FLUKAHadronInelasticPhysics::ConstructProcess() {
   // NO NEUTRON FISSION
 
   // PI+, PI-
-  build_G4_process_helpers::buildInelasticProcess(G4PionPlus::PionPlus(),
-                                                  helper,
-                                                  flukaInelasticScatteringXS,
-                                                  flukaModel);
-  build_G4_process_helpers::buildInelasticProcess(G4PionMinus::PionMinus(),
-                                                  helper,
-                                                  flukaInelasticScatteringXS,
-                                                  flukaModel);
-
+  build_G4_process_helpers::buildInelasticProcess(G4PionPlus::PionPlus(), helper,
+                                                  flukaInelasticScatteringXS, flukaModel);
+  build_G4_process_helpers::buildInelasticProcess(G4PionMinus::PionMinus(), helper,
+                                                  flukaInelasticScatteringXS, flukaModel);
 
   // KAONS
-  build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetKaons(), 
-                                                                 helper,
-                                                                 flukaInelasticScatteringXS,
-                                                                 flukaModel);
-
+  build_G4_process_helpers::buildInelasticProcessForEachParticle(
+    G4HadParticles::GetKaons(), helper, flukaInelasticScatteringXS, flukaModel);
 
   const auto param = G4HadronicParameters::Instance();
   if (param->GetMaxEnergy() > param->EnergyThresholdForHeavyHadrons()) {
-
     // HYPERONS, ANTI-HYPERONS
-    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetHyperons(),
-                                                                   helper,
-                                                                   flukaInelasticScatteringXS,
-                                                                   flukaModel);
-    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetAntiHyperons(),
-                                                                   helper,
-                                                                   flukaInelasticScatteringXS,
-                                                                   flukaModel);
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(
+      G4HadParticles::GetHyperons(), helper, flukaInelasticScatteringXS, flukaModel);
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(
+      G4HadParticles::GetAntiHyperons(), helper, flukaInelasticScatteringXS, flukaModel);
 
     // LIGHT ANTI-IONS: PBAR, NBAR, ANTI LIGHT IONS
-    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetLightAntiIons(),
-                                                                   helper,
-                                                                   flukaInelasticScatteringXS,
-                                                                   flukaModel);
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(
+      G4HadParticles::GetLightAntiIons(), helper, flukaInelasticScatteringXS, flukaModel);
 
     // B-, C- BARYONS AND MESONS
-    if (G4HadronicParameters::Instance()->EnableBCParticles() ) {
-      build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetBCHadrons(),
-                                                                     helper,
-                                                                     flukaInelasticScatteringXS,
-                                                                     flukaModel);
+    if (G4HadronicParameters::Instance()->EnableBCParticles()) {
+      build_G4_process_helpers::buildInelasticProcessForEachParticle(
+        G4HadParticles::GetBCHadrons(), helper, flukaInelasticScatteringXS, flukaModel);
     }
   }
 }
 
+#endif  // G4_USE_FLUKA
 
-#endif // G4_USE_FLUKA
+// ***************************************************************************

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -18,6 +18,7 @@ FLUKA interface included in geant4-11.1.ref05.
 // Includers from project files
 //
 #  include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+#  include "FLUKAHadronInelasticPhysics.hh"
 
 // Includers from Geant4
 //
@@ -32,11 +33,10 @@ FLUKA interface included in geant4-11.1.ref05.
 #  include "globals.hh"
 
 #  include <iomanip>
-// #include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysicsConstructor.hh
+// #include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysics.hh
 
 // Includers from FLUKA interface
 //
-#  include "FLUKAHadronInelasticPhysicsConstructor.hh"
 #  include "fluka_interface.hh"
 
 G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver)
@@ -65,7 +65,7 @@ G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4i
 
   // Hadron Physics
   // RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
-  RegisterPhysics(new FLUKAHadronInelasticPhysicsConstructor(ver));
+  RegisterPhysics(new FLUKAHadronInelasticPhysics(ver));
 
   // Stopping Physics
   RegisterPhysics(new G4StoppingPhysics(ver));

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -18,6 +18,7 @@ FLUKA interface included in geant4-11.1.ref05.
 // Includers from project files
 //
 #  include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+
 #  include "FLUKAHadronInelasticPhysics.hh"
 
 // Includers from Geant4


### PR DESCRIPTION
Add physics constructor for hadron inelastic physics + the fluka.cern inelastic scattering and use it in the customized FTFP_BERT PL. This constructor is adapted from the Geant4 `G4HadronPhysicsFTFP_BERT`, it is intended to be used in comparison with the Geant4 FTFP_BERT PL.