### PR TITLE
Calibration and test updates for v2.6 using Geant4 (v 11.1.ref05)

### DIFF
--- a/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
+++ b/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
@@ -28,7 +28,7 @@ void ATLHECTBanalysis1_v2p6(){
     for ( unsigned int i=11; i<18; i++ ){
         emfiles.push_back( "ATLHECTBout_Run"+std::to_string(i)+".root" );
     }
-    emanalysis( emenergies, emfiles );
+    //emanalysis( emenergies, emfiles );
 
     //Reconstrcuted energies for em runs (G4.11.1.ref05, v2.6)
     //For missing energy points (30, 60, 120, 180 and 200 GeV) using 0.99*beamenergy
@@ -43,7 +43,7 @@ void ATLHECTBanalysis1_v2p6(){
     for ( unsigned int i=0; i<11; i++ ){
         pifiles.push_back( "ATLHECTBout_Run"+std::to_string(i)+".root" );
     }
-    //pianalysis( pienergies, pifiles, recemenergies );
+    pianalysis( pienergies, pifiles, recemenergies );
 
     //Analysis to select channels for pi- analysis
     //

--- a/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
+++ b/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
@@ -28,12 +28,12 @@ void ATLHECTBanalysis1_v2p6(){
     for ( unsigned int i=11; i<18; i++ ){
         emfiles.push_back( "ATLHECTBout_Run"+std::to_string(i)+".root" );
     }
-    //emanalysis( emenergies, emfiles );
+    emanalysis( emenergies, emfiles );
 
-    //Reconstrcuted energies for em runs (G4.10.7.p01, v2.5)
+    //Reconstrcuted energies for em runs (G4.11.1.ref05, v2.6)
     //For missing energy points (30, 60, 120, 180 and 200 GeV) using 0.99*beamenergy
     //
-    vector<double> recemenergies = {19.8165,0.99*30.,39.6759,49.6068,0.99*60.,79.3625,99.2147,118.158,146.643,0.99*180.,0.99*200};
+    vector<double> recemenergies = {19.8678,0.99*30.,39.7708,49.7229,0.99*60.,79.5503,99.4456,118.41,146.933,0.99*180.,0.99*200}; //**Updated (G4.11.1.ref05 v2.6) **
 
     // Analysis of pi- data
     // energies 20, 30, 40, 50, 60, 80, 100, 120, 150, 180, 200 GeV
@@ -43,7 +43,7 @@ void ATLHECTBanalysis1_v2p6(){
     for ( unsigned int i=0; i<11; i++ ){
         pifiles.push_back( "ATLHECTBout_Run"+std::to_string(i)+".root" );
     }
-    pianalysis( pienergies, pifiles, recemenergies );
+    //pianalysis( pienergies, pifiles, recemenergies );
 
     //Analysis to select channels for pi- analysis
     //

--- a/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
+++ b/analysis/v2.6/ATLHECTBanalysis1_v2p6.C
@@ -33,7 +33,7 @@ void ATLHECTBanalysis1_v2p6(){
     //Reconstrcuted energies for em runs (G4.11.1.ref05, v2.6)
     //For missing energy points (30, 60, 120, 180 and 200 GeV) using 0.99*beamenergy
     //
-    vector<double> recemenergies = {19.8678,0.99*30.,39.7708,49.7229,0.99*60.,79.5503,99.4456,118.41,146.933,0.99*180.,0.99*200}; //**Updated (G4.11.1.ref05 v2.6) **
+    vector<double> recemenergies = {19.833,0.99*30.,39.6916,49.6423,0.99*60.,79.418,99.2707,118.209,146.685,0.99*180.,0.99*200}; //**Updated (G4.11.1.ref05 v2.6) **
 
     // Analysis of pi- data
     // energies 20, 30, 40, 50, 60, 80, 100, 120, 150, 180, 200 GeV

--- a/analysis/v2.6/emanalysis.h
+++ b/analysis/v2.6/emanalysis.h
@@ -266,7 +266,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
     Sampfractionlegend->SetLineWidth(0);
     //Sampfractionlegend->SetHeader("Sampling fraction e-", "C");
     Sampfractionlegend->AddEntry(G1Sampfraction,
-            "#splitline{ATLHECTB v2.5 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
+            "#splitline{ATLHECTB v2.6 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
     Sampfractionlegend->Draw("same");
     C1Sampfraction->Write();
     delete C1Sampfraction;
@@ -336,7 +336,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
     legend->AddEntry(G1ATLASenres,
         "#splitline{ATLAS HEC }{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}", "ep");
     legend->AddEntry(G1energyresolution,
-            "#splitline{ATLHECTB v2.5 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
+            "#splitline{ATLHECTB v2.6 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
     legend->SetLineWidth(0);
     legend->Draw("same");
     p2->cd();

--- a/analysis/v2.6/emanalysis.h
+++ b/analysis/v2.6/emanalysis.h
@@ -35,7 +35,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
         cout<<"---> Analysis run # "<<RunNo<<", energy(GeV) "<<emenergies[RunNo]<<endl;  
         //Initiate objects through single Run
         //   
-        string filename = "Data1/"+emfiles[RunNo];
+        string filename = "FLUKAComparison/FTFP_BERT_v2.6/"+emfiles[RunNo];
         double energy = emenergies[RunNo];
         TFile* file = TFile::Open( filename.c_str(), "READ" );
         TTree* tree = (TTree*)file->Get( "ATLHECTBout" );
@@ -167,7 +167,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
             // average response 
 	    //
             H1Response->Fill( addchannels / (edep/1000.) ); 
-            H1Recenergy->Fill( (addchannels / 44.88) ); //updated for v2.5 G410.7.1 using SampFraction 
+            H1Recenergy->Fill( (addchannels / 49.2432) ); //updated for v2.6 G411.1.ref05 using SampFraction 
         } //end for loop events
 
         energies[RunNo] = emenergies[RunNo];

--- a/analysis/v2.6/emanalysis.h
+++ b/analysis/v2.6/emanalysis.h
@@ -167,7 +167,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
             // average response 
 	    //
             H1Response->Fill( addchannels / (edep/1000.) ); 
-            H1Recenergy->Fill( (addchannels / 49.2432) ); //updated for v2.6 G411.1.ref05 using SampFraction 
+            H1Recenergy->Fill( (addchannels / 44.9565) ); //updated for v2.6 G411.1.ref05 using SampFraction 
         } //end for loop events
 
         energies[RunNo] = emenergies[RunNo];
@@ -266,7 +266,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
     Sampfractionlegend->SetLineWidth(0);
     //Sampfractionlegend->SetHeader("Sampling fraction e-", "C");
     Sampfractionlegend->AddEntry(G1Sampfraction,
-            "#splitline{ATLHECTB v2.5 }{Geant4.10.7.p01 FTFP_BERT }","ep");
+            "#splitline{ATLHECTB v2.5 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
     Sampfractionlegend->Draw("same");
     C1Sampfraction->Write();
     delete C1Sampfraction;
@@ -336,7 +336,7 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
     legend->AddEntry(G1ATLASenres,
         "#splitline{ATLAS HEC }{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}", "ep");
     legend->AddEntry(G1energyresolution,
-            "#splitline{ATLHECTB v2.5 }{Geant4.10.7.p01 FTFP_BERT }","ep");
+            "#splitline{ATLHECTB v2.5 }{Geant4.11.1.ref05 FTFP_BERT }","ep");
     legend->SetLineWidth(0);
     legend->Draw("same");
     p2->cd();
@@ -367,15 +367,15 @@ void emanalysis( const vector<double>& emenergies, const vector<string>& emfiles
 
     // Final print out
     //
-    double k;
+    double k = 0.;
     for (unsigned int i = 0; i<emenergies.size(); i++){
         k += responses[i];
     }
-    double r;
+    double r = 0.;
     for (unsigned int i = 0; i<emenergies.size(); i++){
 	r += Sampfraction[i];
     }
-		
+
     cout<<"->Average sampling fraction to e-: "<<r/double(emenergies.size())<<"%"<<endl;
     cout<<"->Average response to e-: "<<k/double(emenergies.size())<<" a.u./GeV"<<endl;
     cout<<"->Reconstructed energies for 20,40,50,80,100,119.1,147.8 GeV e-: "<<endl;

--- a/analysis/v2.6/pianalysis.h
+++ b/analysis/v2.6/pianalysis.h
@@ -42,7 +42,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
         cout<<"---> Analysis run # "<<RunNo<<", energy(GeV) "<<pienergies[RunNo]<<endl;  
         //Initiate objects through single Run
         //   
-        string filename = "Data1/"+pifiles[RunNo];
+        string filename = "FLUKAComparison/FTFP_BERT_v2.6/"+pifiles[RunNo];
         double energy = pienergies[RunNo];
         TFile* file = TFile::Open( filename.c_str(), "READ" );
         TTree* tree = (TTree*)file->Get( "ATLHECTBout" );
@@ -359,7 +359,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     Freslegend->AddEntry(G1energyresolution,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     Freslegend->SetLineWidth(0);
     Freslegend->Draw("same");
@@ -424,7 +424,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     legend->AddEntry(G1responses,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     legend->SetLineWidth(0);
     legend->Draw("same");
@@ -493,7 +493,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     F1legend->AddEntry(G1F1,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     F1legend->SetLineWidth(0);
     F1legend->Draw("same");
@@ -551,7 +551,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     F2legend->AddEntry(G1F2,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     F2legend->SetLineWidth(0);
     F2legend->Draw("same");
@@ -610,7 +610,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     F3legend->AddEntry(G1F3,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     F3legend->SetLineWidth(0);
     F3legend->Draw("same");
@@ -670,7 +670,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     F4legend->AddEntry(G1F4,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     F4legend->SetLineWidth(0);
     F4legend->Draw("same");
@@ -735,7 +735,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     L0legend->AddEntry(G1L0,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     L0legend->SetLineWidth(0);
     L0legend->Draw("same");
@@ -790,7 +790,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     "#splitline{ATLAS HEC}{#splitline{Test beam 2000/2001}{ATL-LARG-PUB-2022-001}}",
     "ep");
     sigmaL0legend->AddEntry(G1sigmaL0,
-    "#splitline{ATLHECTB v2.5 }{#splitline{Geant4.10.7.p01 FTFP_BERT }{w/ Birks Law}}",
+    "#splitline{ATLHECTB v2.6 }{#splitline{Geant4.11.1.ref05 FTFP_BERT }{w/ Birks Law}}",
     "ep");
     sigmaL0legend->SetLineWidth(0);
     sigmaL0legend->Draw("same");

--- a/analysis/v2.6/pianalysis.h
+++ b/analysis/v2.6/pianalysis.h
@@ -226,8 +226,8 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
             //Using SF from emanalysis for calibration
             //
             //H1Response->Fill( (addchannels / pienergies[RunNo])/44.88); //pi/e
-            H1Response->Fill( (addchannels / recemenergies[RunNo])/49.2432 ); //updated for v2.6 G411.1.ref05 using SampFraction 
-            H1Recenergy->Fill( addchannels /49.2432 ); //updated for v2.6 G411.1.ref05 using SampFraction 
+            H1Response->Fill( (addchannels / recemenergies[RunNo])/44.9565 ); //updated for v2.6 G411.1.ref05 using SampFraction 
+            H1Recenergy->Fill( addchannels /44.9565 ); //updated for v2.6 G411.1.ref05 using SampFraction 
         } //end for loop events
 
         energies[RunNo] = pienergies[RunNo];
@@ -407,7 +407,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     G1ATLASresponse->SetMarkerStyle(8);
     G1ATLASresponse->GetXaxis()->SetTitle("<E_{Beam}> [GeV]");
     G1ATLASresponse->GetYaxis()->SetTitle("#pi/e");
-    G1ATLASresponse->GetYaxis()->SetRangeUser(0.75,0.9);
+    G1ATLASresponse->GetYaxis()->SetRangeUser(0.7,0.9);
     G1ATLASresponse->GetXaxis()->SetRangeUser(0.,220.);
     G1ATLASresponse->SetTitle("");
     G1ATLASresponse->SetName("pi-ATLASresponse");
@@ -818,7 +818,7 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
     delete outputfile;
     // Final print out
     //
-    double k;
+    double k = 0.;
     for (unsigned int i = 0; i<pienergies.size(); i++){
         k += responses[i];
     }

--- a/analysis/v2.6/pianalysis.h
+++ b/analysis/v2.6/pianalysis.h
@@ -226,8 +226,8 @@ void pianalysis( const vector<double>& pienergies, const vector<string>& pifiles
             //Using SF from emanalysis for calibration
             //
             //H1Response->Fill( (addchannels / pienergies[RunNo])/44.88); //pi/e
-            H1Response->Fill( (addchannels / recemenergies[RunNo])/44.88); //pi/e
-            H1Recenergy->Fill( addchannels /44.88);
+            H1Response->Fill( (addchannels / recemenergies[RunNo])/49.2432 ); //updated for v2.6 G411.1.ref05 using SampFraction 
+            H1Recenergy->Fill( addchannels /49.2432 ); //updated for v2.6 G411.1.ref05 using SampFraction 
         } //end for loop events
 
         energies[RunNo] = pienergies[RunNo];


### PR DESCRIPTION
I report a brief summary of the commits generated for the three modified files (ATLHECTBanalysis1_v2p6.C, emanalysis.h, pianalysis.h) : 

- **ATLHECTBanalysis1_v2p6.C**: Updated the reconstructed e- energies to the G4.11.1.ref05 version (v2.6)
- **emanalysis.h**: Updated the SampFraction to the new G4.11.1.ref05 version (v2.6), updated the names of the Canvas legends to G4.11.1.ref05 (v2.6), Changed the initialization of the double variables by setting them to 0. at the start.
- **pianalysis.h**: Updated the SampFraction to the new G4.11.1.ref05 version (v2.6), updated the names of the Canvas legends to G4.11.1.ref05 (v2.6), Changed the initialization of the double variables by setting them to 0. at the start.